### PR TITLE
Add optional abstract field to search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valyu/ai-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Valyu search tools for Vercel AI SDK",
   "files": [
     "dist"

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,6 +252,8 @@ export interface ValyuSearchResult {
   authors?: string[];
   /** Markdown references for citations in the content */
   references?: string;
+  /** Abstract or summary (for academic content) */
+  abstract?: string;
   /** Any additional metadata fields */
   [key: string]: any;
 }


### PR DESCRIPTION
Adds optional `abstract` field to `ValyuSearchResult` type for sources that return abstracts.