### PR TITLE
Centralize HTTP client configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@valyu/ai-sdk",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@valyu/ai-sdk",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "dotenv": "17.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valyu/ai-sdk",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Valyu search tools for Vercel AI SDK",
   "files": [
     "dist"

--- a/src/bio-search.ts
+++ b/src/bio-search.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ValyuBioSearchConfig } from "./types.js";
+import { valyuFetch } from "./http.js";
 
 /**
  * Creates a biomedical search tool powered by Valyu for use with Vercel AI SDK
@@ -78,12 +79,7 @@ export function bioSearch(config: ValyuBioSearchConfig = {}) {
 
       // Call Valyu API
       try {
-        const response = await fetch("https://api.valyu.ai/v1/deepsearch", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-          },
+        const response = await valyuFetch("/deepsearch", apiKey, {
           body: JSON.stringify(requestBody),
         });
 

--- a/src/company-research.ts
+++ b/src/company-research.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ValyuCompanyResearchConfig } from "./types.js";
+import { valyuFetch } from "./http.js";
 
 /**
  * Creates a company research tool powered by Valyu for use with Vercel AI SDK
@@ -57,8 +58,6 @@ export function companyResearch(config: ValyuCompanyResearchConfig = {}) {
         throw new Error("VALYU_API_KEY is required. Set it in environment variables or pass it in config.");
       }
 
-      const VALYU_API_BASE = "https://api.valyu.ai/v1";
-
       // Helper to check if response has insufficient information
       const hasInsufficientInfo = (content: string) => {
         if (!content) return true;
@@ -91,12 +90,7 @@ export function companyResearch(config: ValyuCompanyResearchConfig = {}) {
           ...options,
         };
 
-        const response = await fetch(`${VALYU_API_BASE}/answer`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-          },
+        const response = await valyuFetch("/answer", apiKey, {
           body: JSON.stringify(payload),
         });
 

--- a/src/datasources.ts
+++ b/src/datasources.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { valyuFetch } from "./http.js";
 
 /**
  * Configuration for datasources tool
@@ -49,18 +50,16 @@ export function datasources(config: ValyuDatasourcesConfig = {}) {
         throw new Error("VALYU_API_KEY is required. Set it in environment variables or pass it in config.");
       }
 
-      // Build URL with optional category parameter
-      let url = "https://api.valyu.ai/v1/datasources";
+      // Build endpoint with optional category parameter
+      let endpoint = "/datasources";
       if (category) {
-        url += `?category=${encodeURIComponent(category)}`;
+        endpoint += `?category=${encodeURIComponent(category)}`;
       }
 
       try {
-        const response = await fetch(url, {
+        const response = await valyuFetch(endpoint, apiKey, {
           method: "GET",
-          headers: {
-            "x-api-key": apiKey,
-          },
+          contentType: false,
         });
 
         if (!response.ok) {
@@ -116,11 +115,9 @@ export function datasourcesCategories(config: ValyuDatasourcesConfig = {}) {
       }
 
       try {
-        const response = await fetch("https://api.valyu.ai/v1/datasources/categories", {
+        const response = await valyuFetch("/datasources/categories", apiKey, {
           method: "GET",
-          headers: {
-            "x-api-key": apiKey,
-          },
+          contentType: false,
         });
 
         if (!response.ok) {

--- a/src/economics-search.ts
+++ b/src/economics-search.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ValyuEconomicsSearchConfig } from "./types.js";
+import { valyuFetch } from "./http.js";
 
 /**
  * Creates an economics and statistics search tool powered by Valyu for use with Vercel AI SDK
@@ -72,12 +73,7 @@ export function economicsSearch(config: ValyuEconomicsSearchConfig = {}) {
 
       // Call Valyu API
       try {
-        const response = await fetch("https://api.valyu.ai/v1/deepsearch", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-          },
+        const response = await valyuFetch("/deepsearch", apiKey, {
           body: JSON.stringify(requestBody),
         });
 

--- a/src/finance-search.ts
+++ b/src/finance-search.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ValyuFinanceSearchConfig } from "./types.js";
+import { valyuFetch } from "./http.js";
 
 /**
  * Creates a finance search tool powered by Valyu for use with Vercel AI SDK v5 and v6
@@ -81,12 +82,7 @@ export function financeSearch(config: ValyuFinanceSearchConfig = {}) {
 
       // Call Valyu API
       try {
-        const response = await fetch("https://api.valyu.ai/v1/deepsearch", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-          },
+        const response = await valyuFetch("/deepsearch", apiKey, {
           body: JSON.stringify(requestBody),
         });
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,28 @@
+const SDK_NAME = "@valyu/ai-sdk";
+const SDK_VERSION = "1.1.4";
+const BASE_URL = "https://api.valyu.ai/v1";
+
+const sdkHeaders = {
+  "User-Agent": `valyu-ai-sdk/${SDK_VERSION}`,
+  "X-Valyu-SDK": "valyu-ai-sdk",
+  "X-Valyu-SDK-Version": SDK_VERSION,
+};
+
+export { BASE_URL };
+
+export function valyuFetch(
+  endpoint: string,
+  apiKey: string,
+  options: { method?: string; body?: string; contentType?: boolean } = {}
+): Promise<Response> {
+  const { method = "POST", body, contentType = true } = options;
+  return fetch(`${BASE_URL}${endpoint}`, {
+    method,
+    headers: {
+      ...(contentType && { "Content-Type": "application/json" }),
+      "x-api-key": apiKey,
+      ...sdkHeaders,
+    },
+    ...(body && { body }),
+  });
+}

--- a/src/paper-search.ts
+++ b/src/paper-search.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ValyuPaperSearchConfig } from "./types.js";
+import { valyuFetch } from "./http.js";
 
 /**
  * Creates a research paper search tool powered by Valyu for use with Vercel AI SDK v5 and v6
@@ -71,12 +72,7 @@ export function paperSearch(config: ValyuPaperSearchConfig = {}) {
 
       // Call Valyu API
       try {
-        const response = await fetch("https://api.valyu.ai/v1/deepsearch", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-          },
+        const response = await valyuFetch("/deepsearch", apiKey, {
           body: JSON.stringify(requestBody),
         });
 

--- a/src/patent-search.ts
+++ b/src/patent-search.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ValyuPatentSearchConfig } from "./types.js";
+import { valyuFetch } from "./http.js";
 
 /**
  * Creates a patent search tool powered by Valyu for use with Vercel AI SDK
@@ -66,12 +67,7 @@ export function patentSearch(config: ValyuPatentSearchConfig = {}) {
 
       // Call Valyu API
       try {
-        const response = await fetch("https://api.valyu.ai/v1/deepsearch", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-          },
+        const response = await valyuFetch("/deepsearch", apiKey, {
           body: JSON.stringify(requestBody),
         });
 

--- a/src/sec-search.ts
+++ b/src/sec-search.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ValyuSecSearchConfig } from "./types.js";
+import { valyuFetch } from "./http.js";
 
 /**
  * Creates an SEC filings search tool powered by Valyu for use with Vercel AI SDK
@@ -66,12 +67,7 @@ export function secSearch(config: ValyuSecSearchConfig = {}) {
 
       // Call Valyu API
       try {
-        const response = await fetch("https://api.valyu.ai/v1/deepsearch", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-          },
+        const response = await valyuFetch("/deepsearch", apiKey, {
           body: JSON.stringify(requestBody),
         });
 

--- a/src/web-search.ts
+++ b/src/web-search.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { ValyuWebSearchConfig } from "./types.js";
+import { valyuFetch } from "./http.js";
 
 /**
  * Creates a web search tool powered by Valyu for use with Vercel AI SDK v5 and v6
@@ -79,12 +80,7 @@ export function webSearch(config: ValyuWebSearchConfig = {}) {
 
       // Call Valyu API
       try {
-        const response = await fetch("https://api.valyu.ai/v1/deepsearch", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-          },
+        const response = await valyuFetch("/deepsearch", apiKey, {
           body: JSON.stringify(requestBody),
         });
 


### PR DESCRIPTION
## Summary
- Create shared `src/http.ts` fetch wrapper with standardized SDK attribution headers (`User-Agent`, `X-Valyu-SDK`, `X-Valyu-SDK-Version`)
- Deduplicate base URL and header configuration across 9 fetch call sites
- Bump version to 1.1.4

## Changes
- **New**: `src/http.ts` - Shared `valyuFetch()` function with SDK metadata headers
- **Modified**: All 9 tool files updated to use `valyuFetch()` instead of raw `fetch()`
  - `web-search.ts`, `finance-search.ts`, `paper-search.ts`, `bio-search.ts`
  - `patent-search.ts`, `sec-search.ts`, `economics-search.ts`
  - `company-research.ts`, `datasources.ts` (2 call sites)

## Notes
Eliminates the hardcoded `https://api.valyu.ai/v1` base URL and header objects duplicated across files. Zero breaking changes - all exports remain identical.